### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/talon_handler/main.py
+++ b/src/talon_handler/main.py
@@ -14,9 +14,28 @@ from .discovery import scan_local_ports
 from .monitor import TalonMonitor
 from .telegram_bot import TalonBot
 from .constants import PID_FILE
+from . import __version__
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"Talon Handler version: {__version__}")
+        raise typer.Exit()
 
 app = typer.Typer(help="🦅 Talon Handler: Homelab Service Discovery & Monitoring")
 console = Console()
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        help="Show the version and exit.",
+        callback=version_callback,
+        is_eager=True,
+    )
+):
+    pass
 
 def is_running():
     if os.path.exists(PID_FILE):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,9 @@
 import pytest
 from talon_handler.config import generate_otp
 from talon_handler.discovery import scan_local_ports
+from talon_handler.main import app
+from typer.testing import CliRunner
+from talon_handler import __version__
 
 def test_otp_generation():
     otp = generate_otp()
@@ -14,3 +17,10 @@ def test_discovery_structure():
     for port, name in found:
         assert isinstance(port, int)
         assert isinstance(name, str)
+
+def test_version_flag():
+    """Test that --version flag displays the correct version."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"Talon Handler version: {__version__}" in result.output


### PR DESCRIPTION
## Summary

This PR adds a `--version` flag to the Talon Handler CLI, allowing users to quickly check the installed version.

## Changes

- Added `version_callback()` function to display version information
- Registered `--version` / `-v` flag using typer's callback mechanism
- Added test case `test_version_flag()` to verify the functionality
- Version is dynamically read from `__init__.__version__`

## Testing

- All existing tests pass (3/3)
- New test for version flag passes
- Manually tested with `talon --version`:
  ```
  Talon Handler version: 0.1.7
  ```

## Checklist

- [x] Code builds successfully
- [x] All existing tests pass
- [x] New code includes test coverage
- [x] Local testing confirms functionality

Closes #1